### PR TITLE
Don't skip `script:` step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
   include:
     - stage: deploy
       install: skip
-      script: skip
+      script: true
       after_success: skip
       before_deploy: echo $CI_COMMIT_TAG > asciigraf/VERSION
       python: "3.6"


### PR DESCRIPTION
Hello!

I'm a Customer Support Engineer @ Travis CI and I believe the reason we are not running your deployment is because you are skipping the `script:` step. It's not intuitive but I'll look on how to make it more.

Please let me know if this works!

Thanks!