### PR TITLE
Run flake8 as part of the CI process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ python:
   - "3.5"
   - "3.4"
   - "2.7"
-install: pip install tox coveralls
-script: tox
+install: pip install tox coveralls flake8
+script:
+  - flake8
+  - tox
 after_success: coveralls
 
 jobs:

--- a/asciigraf/__init__.py
+++ b/asciigraf/__init__.py
@@ -5,4 +5,4 @@
 # LICENSE file in the root directory of this source tree.
 #############################################################################
 
-from .asciigraf import graph_from_ascii
+from .asciigraf import graph_from_ascii # noqa F401

--- a/tests/test_asciigraf.py
+++ b/tests/test_asciigraf.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 import pytest
 
 from asciigraf import graph_from_ascii
-from asciigraf.asciigraf import node_iter, Point, BadEdgeException
+from asciigraf.asciigraf import node_iter, Point
 
 
 def test_ascii_positions():


### PR DESCRIPTION
I noticed when trying to add a test for `BadEdgeException` that there were 2 flake8 warnings. I added flake8 to run in the CI and then fixed the two warnings.