### PR TITLE
Vertical line labels

### DIFF
--- a/asciigraf/asciigraf.py
+++ b/asciigraf/asciigraf.py
@@ -50,7 +50,7 @@ def graph_from_ascii(network_string):
 
     # Second pass to correct vertical labels. This needs to be
     # a correction so that the OrderedDict is correctly setup
-    for root_position, label in line_labels.items():
+    for root_position, label in list(line_labels.items()):
         is_vertical_label = any(
             above in edge_chars and edge_chars[above] == '|'
             for above in (
@@ -73,8 +73,7 @@ def graph_from_ascii(network_string):
                         del edge_chars[pos]
                 except KeyError:
                     # pass
-                    if pos in edge_chars:
-                        del edge_chars[pos]
+                    del edge_chars[pos]
 
     edge_char_to_edge_map = {}
     edges = []

--- a/tests/test_asciigraf.py
+++ b/tests/test_asciigraf.py
@@ -193,3 +193,24 @@ def test_line_labels():
 
     assert graph.get_edge_data("D", "E")["label"] == "string"
     assert graph.get_edge_data("D", "E")["length"] == 15
+
+
+def test_vertical_line_labels():
+    graph = graph_from_ascii("""
+        A
+        |
+      (Vertical)
+        |
+        B
+    """)
+
+    assert set(graph.nodes()) == {
+        "A", "B"
+    }
+
+    assert set(graph.edges()) == {
+        ("A", "B")
+    }
+
+    assert graph.get_edge_data("A", "B")["label"] == "Vertical"
+    assert graph.get_edge_data("A", "B")["length"] == 3

--- a/tests/test_asciigraf.py
+++ b/tests/test_asciigraf.py
@@ -214,3 +214,25 @@ def test_vertical_line_labels():
 
     assert graph.get_edge_data("A", "B")["label"] == "Vertical"
     assert graph.get_edge_data("A", "B")["length"] == 3
+
+
+def test_vertical_line_adjacent_labels():
+    graph = graph_from_ascii("""
+                C
+        A---D   |
+          (Vertical)
+                |
+                B
+    """)
+
+    assert set(graph.nodes()) == {
+        "A", "B", "C", "D"
+    }
+
+    assert set(graph.edges()) == {
+        ("A", "D"),
+        ("C", "B")
+    }
+
+    assert graph.get_edge_data("C", "B")["label"] == "Vertical"
+    assert graph.get_edge_data("C", "B")["length"] == 3


### PR DESCRIPTION
Adds support for labeling vertical lines. This was easier said than done. I think it might help overall if it was easier to look for a character at a given grid square (perhaps an accessor around the string?). That way this could all be done in one pass rather than 2 but I think that might be better in it's own PR.

From the test:

```python
def test_vertical_line_labels():
    graph = graph_from_ascii("""
        A
        |
      (Vertical)
        |
        B
    """)
```