### PR TITLE
Support more corner types

### DIFF
--- a/asciigraf/asciigraf.py
+++ b/asciigraf/asciigraf.py
@@ -79,16 +79,28 @@ def graph_from_ascii(network_string):
     edges = []
 
     for pos, char in edge_chars.items():
-
-        trailing_offset, _ = EDGE_CHAR_NEIGHBOURS[char]
+        trailing_offset, leading_offset = EDGE_CHAR_NEIGHBOURS[char]
         neighbor = pos + trailing_offset
+        neighbor_2 = pos + leading_offset
 
-        if neighbor in edge_char_to_edge_map:  # Add this node to the edge
-            edge_char_to_edge_map[pos] = edge_char_to_edge_map[neighbor]
-            edge_char_to_edge_map[pos]["points"].append(pos)
-        else:  # Make a new edge
-            edge_char_to_edge_map[pos] = dict(points=[pos], nodes=[])
-            edges.append(edge_char_to_edge_map[pos])
+        # we can skip this position if a previous iteration already
+        # mapped the character to an edge
+        if pos not in edge_char_to_edge_map:
+            if neighbor in edge_char_to_edge_map:  # Add this node to the edge
+                edge_char_to_edge_map[pos] = edge_char_to_edge_map[neighbor]
+                edge_char_to_edge_map[pos]["points"].append(pos)
+            else:  # Make a new edge
+                edge_char_to_edge_map[pos] = dict(points=[pos], nodes=[])
+                edges.append(edge_char_to_edge_map[pos])
+
+            # we can look ahead at other neighbor and add it too -- this
+            # step allows us to solve a few extra corner types
+            if (
+                neighbor_2 not in edge_char_to_edge_map
+                and neighbor_2 in edge_chars
+            ):
+                edge_char_to_edge_map[neighbor_2] = edge_char_to_edge_map[pos]
+                edge_char_to_edge_map[pos]["points"].append(neighbor_2)
 
         neighboring_nodes = [
             node_chars[pos+pos_offset]

--- a/tests/test_asciigraf.py
+++ b/tests/test_asciigraf.py
@@ -94,6 +94,35 @@ def test_converts_down_right_angle():
     assert set(graph.edges()) == {("1", "2")}
 
 
+def test_converts_the_other_kind_down_right_angle():
+    graph = graph_from_ascii("""
+            1-|
+              |
+              2         """)
+
+    assert set(graph.nodes()) == {"1", "2"}
+    assert set(graph.edges()) == {("1", "2")}
+
+
+def test_converts_down_left_angle():
+    graph = graph_from_ascii("""
+        1
+        |
+        |--2 """)
+
+    assert set(graph.nodes()) == {"1", "2"}
+    assert set(graph.edges()) == {("1", "2")}
+
+
+def test_converts_other_kind_of_down_left_angle():
+    graph = graph_from_ascii("""
+        1
+        |
+        ---2 """)
+    assert set(graph.nodes()) == {"1", "2"}
+    assert set(graph.edges()) == {("1", "2")}
+
+
 def test_converts_escaped_down_obtuse_angle():
     graph = graph_from_ascii("""
             1--------
@@ -103,9 +132,27 @@ def test_converts_escaped_down_obtuse_angle():
     assert set(graph.edges()) == {("1", "2")}
 
 
+def test_converts_other_kind_of_escaped_down_obtuse_angle():
+    graph = graph_from_ascii("""
+            1-------\\
+                     \\
+                      2      """)
+    assert set(graph.nodes()) == {"1", "2"}
+    assert set(graph.edges()) == {("1", "2")}
+
+
 def test_converts_down_acute_angle():
     graph = graph_from_ascii("""
                 1--------
+                       /
+                      2         """)
+    assert set(graph.nodes()) == {"1", "2"}
+    assert set(graph.edges()) == {("1", "2")}
+
+
+def test_converts_other_kind_of_down_acute_angle():
+    graph = graph_from_ascii("""
+                1-------/
                        /
                       2         """)
     assert set(graph.nodes()) == {"1", "2"}


### PR DESCRIPTION
I can never remember which way a corner was supported -- this makes it easier by supporting multiple corner configurations.


It doesn't cover cases like

```
  |
  |
---
```
...because those require merging two edges.