### PR TITLE
Test long and short vertical labels

### DIFF
--- a/asciigraf/asciigraf.py
+++ b/asciigraf/asciigraf.py
@@ -54,7 +54,7 @@ def graph_from_ascii(network_string):
         is_vertical_label = any(
             above in edge_chars and edge_chars[above] == '|'
             for above in (
-                root_position + Point(i, -1)
+                root_position + Point(i + 1, -1)
                 for i, char in enumerate(label)
             )
         )

--- a/tests/test_asciigraf.py
+++ b/tests/test_asciigraf.py
@@ -271,13 +271,13 @@ def test_line_labels():
     'longlonglabel', 'short', 'l',
 ])
 def test_vertical_line_labels(label):
-    graph = graph_from_ascii(f"""
+    graph = graph_from_ascii("""
         A
         |
        ({label})
         |
         B
-    """)
+    """.format(label=label))
 
     assert set(graph.nodes()) == {
         "A", "B"

--- a/tests/test_asciigraf.py
+++ b/tests/test_asciigraf.py
@@ -267,11 +267,14 @@ def test_line_labels():
     assert graph.get_edge_data("D", "E")["length"] == 15
 
 
-def test_vertical_line_labels():
-    graph = graph_from_ascii("""
+@pytest.mark.parametrize("label", [
+    'longlonglabel', 'short', 'l',
+])
+def test_vertical_line_labels(label):
+    graph = graph_from_ascii(f"""
         A
         |
-      (Vertical)
+       ({label})
         |
         B
     """)
@@ -284,7 +287,7 @@ def test_vertical_line_labels():
         ("A", "B")
     }
 
-    assert graph.get_edge_data("A", "B")["label"] == "Vertical"
+    assert graph.get_edge_data("A", "B")["label"] == label
     assert graph.get_edge_data("A", "B")["length"] == 3
 
 


### PR DESCRIPTION
Looks like the issue is that vertical labels don't work if they're only one character long.