### PR TITLE
Put commit slug in VERSION

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -40,12 +40,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest pytest-coverage
-        pip install -e .
+        pip install -e .[test]
         pip install networkx==${{ matrix.networkx-version }}
     - name: Lint with flake8
       run: |
         flake8
-    - name: Test with tox
+    - name: Test with Pytest
       run: |
         pytest --junitxml=junit/test-results.xml --cov-report term-missing  --cov-report=xml --cov-report=html --cov=asciigraf

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -29,9 +29,11 @@ jobs:
         pip install build
     - name: Update VERSION
       run: |
-        echo ${{ env.GITHUB_REF }} > asciigraf/VERSION
+        echo "${GITHUB_REF#refs/*/}" > asciigraf/VERSION
     - name: Build package
-      run: python -m build
+      run: |
+        echo "Building $(cat asciigraf/VERSION)"
+        python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
         "colorama",
     ],
     extras_require={
-        "test": ["pytest", "pytest-cov"],
+        "test": ["pytest", "pytest-cov", "flake8"],
     },
 )


### PR DESCRIPTION
We need to do this in order to get the right version publisehed.

I tested this on 0.9.1alpha7 and was able to see it publish: https://github.com/opusonesolutions/asciigraf/runs/3034408293?check_suite_focus=true

After this, you can do `pip install asciigraf==0.9.1a7`