### PR TITLE
Network string attribute

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.11
+      - name: Set up Latest Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
@@ -53,20 +53,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy3.8', 'pypy3.9']
-        networkx-version: ['2.4','2.5', '2.6', '2.7', '2.8', '3.0']
+        python-version: ['3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
+        networkx-version: ['2.4','2.5', '2.6', '2.7', '2.8', '3.0', '3.1', '3.2']
         include:
-          - python-version: '3.7'
-            networkx-version: '2.6'
-          - python-version: '3.7'
-            networkx-version: '1.11'
           - python-version: '3.8'
             networkx-version: '1.11'
+          - python-version: '3.8'
+            networkx-version: '2.4'
+          - python-version: '3.8'
+            networkx-version: '3.1' # as of 3.2, python 3.9 is not supported by networkx
         exclude:
             # missing wheels for scipy at these combos
-          - python-version: 'pypy3.9'
+          - python-version: 'pypy3.10'
             networkx-version: '2.6'
-          - python-version: 'pypy3.8'
+          - python-version: 'pypy3.9'
             networkx-version: '2.6'
     steps:
       - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,11 @@ Usage
 -----
 
 Asciigraf expects a string containg a 2-d ascii diagram. Nodes can be an
-alphanumeric string composed of characters in ``A-Z``, ``a-z``, ``0-9``,
-and ``_, {, }``. Edges can be composed of ``-``, ``/``, ``\`` and ``|``.
+alphanumeric string composed of words, sentences and punctuation (for a look at
+what is all tested to work, see the `node recognition tests`_). Edges can be
+composed of ``-``, ``/``, ``\`` and ``|``.
+
+.. _node recognition tests: https://github.com/opusonesolutions/asciigraf/blob/master/tests/test_node_match.py
 
 .. code:: python
 
@@ -57,13 +60,14 @@ and ``_, {, }``. Edges can be composed of ``-``, ``/``, ``\`` and ``|``.
     >>> ['NodeA', 'NodeB']
 
 
-Networkx provides tools to attach data to nodes and edges, and asciigraf
+Networkx provides tools to attach data to graphs, nodes and edges, and asciigraf
 leverages these in a number of ways; in the example below you can see that
 asciigraf uses this to attach a ``x, y`` position tuple to each node
-indicating where on the *(x, y)* plane each node
-starts ( *0,0* is at the top-left). It also attaches a ``length`` attribute
+indicating the line/col position of each node ( *0,0* is at the top-left).
+It also attaches a ``length`` attribute
 to each edge which matches the number of characters in that edge, as well
-as a list of positions for each character an edge
+as a list of positions for each character an edge. In addition, the input data
+is attached as a graph attribute ``ascii_string`` for reference.
 
 .. code:: python
 
@@ -76,6 +80,12 @@ as a list of positions for each character an edge
     print(network.edge['NodeA']['NodeB']['points'])
     >>> [(15, 1), (16, 1), (17, 1), (18, 1),
          (19, 1), (19, 2), (19, 3), (20, 3), (21, 3), (22, 3)]
+
+    print(network.graph["ascii_string"])
+    >>>
+        NodeA-----
+                 |
+                 |---NodeB
 
 
 Asciigraf also lets you annotate the edges of graphs using in-line labels ---
@@ -90,7 +100,7 @@ on which it is drawn with the attribute name ``label``.
                       |
                       |
                       |
-                      D---(string)----E
+                      D---(pebbles)----E
 
     """)
 
@@ -101,7 +111,7 @@ on which it is drawn with the attribute name ``label``.
     >>> string
 
     print(network.get_edge_data("D", "E")["label"])
-    >>> string
+    >>> pebbles
 
     print(hasattr(network.get_edge_data("B", "D"), "label"))
     >>> False

--- a/asciigraf/asciigraf.py
+++ b/asciigraf/asciigraf.py
@@ -6,21 +6,15 @@
 #############################################################################
 
 import re
-import sys
 from collections import OrderedDict
 from itertools import chain
 from typing import List, Tuple
 
 import colorama
-from colorama import Style, Fore
 import networkx
+from colorama import Style, Fore
 
 from .point import Point
-
-if sys.version_info >= (3, 7):
-    networkx_Graph = networkx.Graph
-else:
-    networkx_Graph = networkx.OrderedGraph
 
 LEFT, RIGHT = Point(-1, 0), Point(1, 0)
 ABOVE, BELOW = Point(0, -1), Point(0, 1)
@@ -124,7 +118,7 @@ def get_edges(network_string, nodes, labels):
 
 def build_networkx_graph(nodes, edges):
     # Build networkx datastructure
-    ascii_graph = networkx_Graph()
+    ascii_graph = networkx.Graph()
     ascii_graph.add_nodes_from(
         (node, {"position": tuple(pos)}) for pos, node in nodes.items()
     )

--- a/asciigraf/asciigraf.py
+++ b/asciigraf/asciigraf.py
@@ -43,7 +43,9 @@ def graph_from_ascii(network_string):
     """
     nodes, labels = get_nodes_and_labels(network_string)
     edges = get_edges(network_string, nodes, labels)
-    return build_networkx_graph(nodes, edges)
+    graph = build_networkx_graph(nodes, edges)
+    graph.graph["ascii_string"] = network_string
+    return graph
 
 
 def get_edges(network_string, nodes, labels):

--- a/asciigraf/point.py
+++ b/asciigraf/point.py
@@ -32,7 +32,7 @@ class Point(object):
         return "Point({}, {})".format(self.x, self.y)
 
     def __eq__(self, other):
-        return (type(self) == type(other) and
+        return (type(self) is type(other) and
                 self.x == other.x and
                 self.y == other.y
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -38,11 +37,11 @@ repository = "https://github.com/opusonesolutions/asciigraf"
 
 ## build specification
 [build-system]
-requires = ["setuptools >= 61.0.0"]
+requires = ["setuptools >= 66.1.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]
-version = {file = ["asciigraf/VERSION"]}
+version = {file = "asciigraf/VERSION"}
 
 [tool.setuptools.packages.find]
 include=["asciigraf*"]

--- a/tests/test_graph_attributes.py
+++ b/tests/test_graph_attributes.py
@@ -10,6 +10,18 @@ import networkx
 from asciigraf import graph_from_ascii
 
 
+def test_ascii_string_attribute():
+    ascii_string = """
+        NodeA-----
+                 |
+                 |---NodeB
+                                 """
+
+    graph = graph_from_ascii(ascii_string)
+
+    assert graph.graph["ascii_string"] == ascii_string
+
+
 def test_line_lengths():
     graph = graph_from_ascii("""
             <13>           <10>


### PR DESCRIPTION
## Functionality Change

To provide useful error handling, `asciigraf` generates error messages that hightlight bad edges using colour (see the `highlight_bad_edge_characters` function). 

For libraries that use `asciigraf`, there may at times be value in being able to generate similar highlighting to provide error feedback to a user (e.g. if a library has specific rules about what kinds of node labels are valid, and wants to raise an error highlighting a bad one).

Including the ascii string as a graph attribute makes this funcitonality easier to build, since the calling code can reproduce the input text just by having the graph. Libraries can do things like defining a function to produce highlighting:

```python
def highlight_node(asciigraf_obj: networkx.Graph, node: str) -> str:
    ...

def highlight_edge(asciigraf_obj: networkx.Graph, edge: Tuple[str, str]) -> str:
    ...
```

These functions can find the positions of `node` or `edge` using node / edge attributes on the input graph, and can reconstruct a highlighted textual version of the source asciigram. Without the change here, we would need to pass the ascii string separately.

## Additional Changes

1. added a `py.typed` so that mypy can introspect
2. dropped support for python 3.7, pypy3.8(EOL), added testing against python 3.12, pypy3.10
3. some minor changes to README.rst to better describe what kinds of nodes are supported