### PR TITLE
Switch to 'main' as default branch

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -6,10 +6,10 @@ name: Python package
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   lint:

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ alphanumeric string composed of words, sentences and punctuation (for a look at
 what is all tested to work, see the `node recognition tests`_). Edges can be
 composed of ``-``, ``/``, ``\`` and ``|``.
 
-.. _node recognition tests: https://github.com/opusonesolutions/asciigraf/blob/master/tests/test_node_match.py
+.. _node recognition tests: https://github.com/opusonesolutions/asciigraf/blob/main/tests/test_node_match.py
 
 .. code:: python
 


### PR DESCRIPTION
"master" has fallen out of favour as it connotes master vs slave, and we don't need to talk about masters and slaves when we're doing PRs. Also, main has become the default branch for gitlab and github, so this is consistent with other projects going forward